### PR TITLE
Create API endpoint to retrieve news by ID

### DIFF
--- a/src/controllers/news.controllers.js
+++ b/src/controllers/news.controllers.js
@@ -1,18 +1,33 @@
 import { v2 as cloudinary } from "cloudinary";
 import News from "../models/news.model.js";
 
-export const getNews = async (req, res) => {
+export const getAllNews = async (req, res, next) => {
   try {
     const news = await News.find({});
+
     res.status(200).json(news);
-  } catch {
-    res.status(500).json({
-      message: "Internal server error.",
-    });
+  } catch (error) {
+    next(error);
   }
 };
 
-export const createNews = async (req, res) => {
+export const getNews = async (req, res, next) => {
+  try {
+    const newsId = req.params.id;
+    const news = await News.findById(newsId);
+
+    if (!news) {
+      return res
+        .status(404)
+        .json({ message: `News not found with this ${newsId}` });
+    }
+    res.status(200).json(news);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createNews = async (req, res, next) => {
   const { title, content, tags, category } = req.body;
 
   if (!title || !content)
@@ -63,9 +78,7 @@ export const createNews = async (req, res) => {
       message: "News created successfully.",
       news,
     });
-  } catch {
-    res.status(500).json({
-      message: "Internal server error.",
-    });
+  } catch (error) {
+    next(error);
   }
 };

--- a/src/routes/news.routes.js
+++ b/src/routes/news.routes.js
@@ -1,6 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
-import { getNews, createNews } from "../controllers/news.controllers.js";
+import {
+  getAllNews,
+  getNews,
+  createNews,
+} from "../controllers/news.controllers.js";
 
 const newsRoute = Router();
 const upload = multer({
@@ -8,6 +12,7 @@ const upload = multer({
 });
 
 newsRoute.post("/", upload.single("imageUrl"), createNews);
-newsRoute.get("/", getNews);
+newsRoute.get("/", getAllNews);
+newsRoute.get("/:id", getNews);
 
 export default newsRoute;


### PR DESCRIPTION
Add an API endpoint to fetch news articles by their ID, enhancing the existing news retrieval functionality. Update the news route to include this new endpoint and improve error handling in the existing functions.