### PR TITLE
Filter for articles with non-empty image URLs

### DIFF
--- a/src/controllers/article.controllers.js
+++ b/src/controllers/article.controllers.js
@@ -50,7 +50,7 @@ export const getLatestArticles = async (req, res) => {
     };
 
     if (hasImage) {
-      filter.imageUrl = { $exists: true, $ne: "" };
+      filter.imageUrl = { $exists: true, $nin: ["", null] };
     }
 
     const articles = await Article.find(filter).sort({ publishedAt: -1 }).limit(limit);


### PR DESCRIPTION
Update the filter to ensure that only articles with a valid `imageUrl` are retrieved, excluding empty strings and null values.

Done
Resolves #49